### PR TITLE
feat: Toggle tree node on Enter

### DIFF
--- a/src/bin/dtui/components/objects_view.rs
+++ b/src/bin/dtui/components/objects_view.rs
@@ -111,6 +111,9 @@ impl Component for ObjectsView {
 
                                 _ => (),
                             }
+                        } else {
+                            // If not an invokable member toggle the tree
+                            self.objects.state.toggle(selected.to_vec());
                         }
                     }
                 }


### PR DESCRIPTION
When the node in the objects view is not invokable we toggle, i.e. expand or collapse the node